### PR TITLE
Fixed an issue which doesn't write key value and some clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ allows it to read and localize ts resource files. This plugins is optimized for 
 
 ## Release Notes
 v1.1.0
-* Fixed an issue which doesn't not generated `key` value.
+* Fixed an issue case which a `key` value is not written to TS file.
 
 v1.0.0
 * Implemented to generate [TS](https://doc.qt.io/qt-5/linguist-ts-file-format.html) style resource file.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.0
+* Fixed an issue which doesn't not generated `key` value.
+
 v1.0.0
 * Implemented to generate [TS](https://doc.qt.io/qt-5/linguist-ts-file-format.html) style resource file.
   Here's simple output example.

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -183,11 +183,17 @@ TSResourceFile.prototype.getContent = function() {
                         },
                         "source": {
                             "$t": resource.getSource()
-                        },
-                        "translation": {
-                            "$t": resource.getTarget()
                         }
                     };
+
+                    if (resource.getSource() !== resource.getKey()) {
+                        messageObj["comment"] = {
+                            "$t": resource.getKey()
+                        }
+                    }
+                    messageObj["translation"] = {
+                        "$t": resource.getTarget()
+                    }
 
                     if (typeof (resource.getComment()) !== "undefined") {
                         messageObj["extracomment"] = {

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -172,7 +172,8 @@ TSResourceFile.prototype.getContent = function() {
             }
 
             if (resource.getSource() && resource.getTarget()) {
-                if (clean(resource.getSource()) !== clean(resource.getTarget())) {
+                if (clean(resource.getSource()) !== clean(resource.getTarget()) ||
+                    clean(resource.getKey()) !== clean(resource.getTarget()) ) {
                     logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
 
                     filename = this.getFileName(resource.getPath());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -132,6 +132,46 @@ module.exports.tsresourcefile = {
         test.ok(tsrf.isDirty());
         test.done();
     },
+    testTSResourceFileRightContentsWithComment: function(test) {
+        test.expect(2);
+
+        var tsrf = new TSResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        test.ok(tsrf);
+        var resource = new ContextResourceString({
+                type: "string",
+                project: "inputcommon",
+                pathName: "./src/Hello.qml",
+                targetLocale: "de-DE",
+                key: "source text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellentext",
+                context: "Hello",
+                comment: "i18n comments"
+
+            });
+        tsrf.addResource(resource);
+        test.equal(tsrf.getContent(),
+         '<?xml version="1.0" encoding="utf-8"?>\n' +
+         '<!DOCTYPE TS>\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '  <context>\n' +
+         '    <name>Hello</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Hello.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <translation>Quellentext</translation>\n' +
+         '      <extracomment>i18n comments</extracomment>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '</TS>'
+        );
+        test.done();
+    },
 
     testTSResourceFileRightContents: function(test) {
         test.expect(2);
@@ -374,6 +414,85 @@ module.exports.tsresourcefile = {
          '    <message>\n' +
          '      <location filename="Test2.qml"></location>\n' +
          '      <source>source text</source>\n' +
+         '      <translation>Quellen text</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '</TS>'
+        );
+        test.done();
+    },
+    testTSResourceFileRightContents5: function(test) {
+        test.expect(2);
+
+        var tsrf = new TSResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        test.ok(tsrf);
+        [
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                key: "source text key1",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellen text",
+                context: "Test"
+            },
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                key: "more source text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellen text",
+                context: "Test"
+            },
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test2.qml",
+                targetLocale: "de-DE",
+                key: "source text key3",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellen text",
+                context: "Test2"
+            }
+        ].forEach(function(res) {
+            var resource = new ContextResourceString(res);
+            tsrf.addResource(resource);
+        });
+
+        test.equal(tsrf.getContent(),
+         '<?xml version="1.0" encoding="utf-8"?>\n' +
+         '<!DOCTYPE TS>\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '  <context>\n' +
+         '    <name>Test</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>more source text</source>\n' +
+         '      <translation>mehr Quellen text</translation>\n' +
+         '    </message>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <comment>source text key1</comment>\n' +
+         '      <translation>Quellen text</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '  <context>\n' +
+         '    <name>Test2</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test2.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <comment>source text key3</comment>\n' +
          '      <translation>Quellen text</translation>\n' +
          '    </message>\n' +
          '  </context>\n' +


### PR DESCRIPTION
* Fixed an issue that doesn't write `key` value. 
  * If source and key are different, Both value should be written to TS file
```
<unit id="i18nqmlsampler_7" name="aaa">
    <segment>
     <source>Standard</source>
     <target>Standard</target>
    </segment>
   </unit>

```
* Fixed in order not to inherit from FileType and clean up unused codes