### PR TITLE
Changed default srclanguage to en-KR for TS output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.1
+* Changed default sourcelanguage to `en-KR`.
+
 v1.1.0
 * Fixed an issue case which a `key` value is not written to TS file.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
-v1.1.1
+v1.2.0
 * Changed default sourcelanguage to `en-KR`.
 
 v1.1.0

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -241,7 +241,7 @@ TSResourceFile.prototype.getContent = function() {
     var tsContents = {
         "version": "2.1",
         "language": this.locale.getSpec(),
-        "sourcelanguage": "en-US",
+        "sourcelanguage": "en-KR",
         "context": content["context"]
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -158,7 +158,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Hello</name>\n' +
          '    <message>\n' +
@@ -198,7 +198,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Hello</name>\n' +
          '    <message>\n' +
@@ -250,7 +250,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
@@ -317,7 +317,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
@@ -395,7 +395,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
@@ -472,7 +472,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
@@ -538,7 +538,7 @@ module.exports.tsresourcefile = {
         test.equal(tsrf.getContent(),
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-US">\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
@@ -569,7 +569,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getContent(),'<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE" sourcelanguage="en-US"></TS>');
+        test.equal(tsrf.getContent(),'<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE" sourcelanguage="en-KR"></TS>');
         test.done();
     },
 
@@ -772,7 +772,7 @@ module.exports.tsresourcefile = {
             tsrf.addResource(resource);
         });
 
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="ko-KR" sourcelanguage="en-US"></TS>';
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="ko-KR" sourcelanguage="en-KR"></TS>';
         var actual = tsrf.getContent();
         
         test.equal(actual, expected);
@@ -823,7 +823,7 @@ module.exports.tsresourcefile = {
         });
 
         // should use the default locale spec in the first line
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE-ASDF" sourcelanguage="en-US"></TS>';
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE-ASDF" sourcelanguage="en-KR"></TS>';
 
         var actual = tsrf.getContent();
         diff(actual, expected);
@@ -876,7 +876,7 @@ module.exports.tsresourcefile = {
         });
 
         // should use the default locale spec in the first line
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE-ASDF" sourcelanguage="en-US"></TS>';
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE TS>\n<TS version="2.1" language="de-DE-ASDF" sourcelanguage="en-KR"></TS>';
 
         var actual = tsrf.getContent();
         diff(actual, expected);


### PR DESCRIPTION
Previously, It was an `en-US` but I've changed to `en-KR`
In order not to modify source string when `en-US` translation is changed.
In webOS App's `project.json` fill will have the following statement too.
`
"sourceLocale": "en-KR",
`