### PR TITLE
Fix resource target path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.2.1
+* Fix resource target path
+
 v1.2.0
 * Changed default sourcelanguage to `en-KR`.
 

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -275,7 +275,7 @@ TSResourceFile.prototype.getResourceFilePath = function(locale) {
     }
     filename = projectId + "_" + filename;
 
-    dir = this.project.getResourceDirs("ts")[0] || ".";
+    dir = path.join(this.project.target, this.project.getResourceDirs("ts")[0] || ".");
     newPath = path.join(dir, filename);
 
     logger.trace("Getting resource file path for locale " + locale + ": " + newPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",
@@ -48,13 +48,13 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.5.0",
+        "ilib": "^14.6.0",
         "log4js": "^2.11.0",
         "pretty-data": "^0.40.0",
         "xml2json": "^0.11.2"
     },
     "devDependencies": {
-        "loctool": "^2.6.0",
+        "loctool": "^2.7.2",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -43,7 +43,7 @@ var p = new CustomProject({
     resourceDirs: {
         "ts": "."
         }
-    }, "./testfiles", {
+    }, ".", {
         locales:["en-GB"]
     });
 
@@ -582,7 +582,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_de.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_de.ts");
         test.done();
     },
 
@@ -608,7 +608,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_de_AT.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_de_AT.ts");
         test.done();
     },
 
@@ -621,7 +621,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_de.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_de.ts");
         test.done();
     },
 
@@ -634,7 +634,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_de_AT_ASDF.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_de_AT_ASDF.ts");
         test.done();
     },
 
@@ -647,7 +647,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_zh.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_zh.ts");
         test.done();
     },
 
@@ -673,7 +673,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_zh_Hant_HK.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_zh_Hant_HK.ts");
         test.done();
     },
 
@@ -686,7 +686,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_zh_Hans_SG.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_zh_Hans_SG.ts");
         test.done();
     },
 
@@ -699,7 +699,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_zh_Hant_TW.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_zh_Hant_TW.ts");
         test.done();
     },
 
@@ -712,7 +712,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_en.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_en.ts");
         test.done();
     },
 
@@ -725,7 +725,7 @@ module.exports.tsresourcefile = {
         });
 
         test.ok(tsrf);
-        test.equal(tsrf.getResourceFilePath(), "locales/quicksettings_de_AT.ts");
+        test.equal(tsrf.getResourceFilePath(), "testfiles/locales/quicksettings_de_AT.ts");
         test.done();
     },
 
@@ -891,13 +891,13 @@ module.exports.tsresourcefile = {
                     "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
 
         var expected = [
-            "locales/quicksettings_en.ts","locales/quicksettings_en_GB.ts",
-            "locales/quicksettings_en_AU.ts","locales/quicksettings_es_CO.ts",
-            "locales/quicksettings_es.ts","locales/quicksettings_et.ts",
-            "locales/quicksettings_fa.ts","locales/quicksettings_fa_AF.ts",
-            "locales/quicksettings_fr.ts","locales/quicksettings_fr_CA.ts",
-            "locales/quicksettings_zh.ts","locales/quicksettings_zh_Hant_HK.ts",
-            "locales/quicksettings_zh_Hant_TW.ts"
+            "testfiles/locales/quicksettings_en.ts","testfiles/locales/quicksettings_en_GB.ts",
+            "testfiles/locales/quicksettings_en_AU.ts","testfiles/locales/quicksettings_es_CO.ts",
+            "testfiles/locales/quicksettings_es.ts","testfiles/locales/quicksettings_et.ts",
+            "testfiles/locales/quicksettings_fa.ts","testfiles/locales/quicksettings_fa_AF.ts",
+            "testfiles/locales/quicksettings_fr.ts","testfiles/locales/quicksettings_fr_CA.ts",
+            "testfiles/locales/quicksettings_zh.ts","testfiles/locales/quicksettings_zh_Hant_HK.ts",
+            "testfiles/locales/quicksettings_zh_Hant_TW.ts"
         ];
         for (var i=0; i<locales.length;i++) {
             tsrf = new TSResourceFile({


### PR DESCRIPTION
Same change with https://github.com/iLib-js/ilib-loctool-webos-json-resource/pull/11
If a target was set, this plugin was not saving resource files in that target dir.