### PR TITLE
Update to generate resource even though source and target are the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.2.2
+* Updated code to generate resource even though source and target are the same.
+
 v1.2.1
-* Fix resource target path
+* Fixed resource target path
 * Updated code to print log with log4js.
 
 v1.2.0

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -173,58 +173,52 @@ TSResourceFile.prototype.getContent = function() {
             }
 
             if (resource.getSource() && resource.getTarget()) {
-                if (clean(resource.getSource()) !== clean(resource.getTarget()) ||
-                    clean(resource.getKey()) !== clean(resource.getTarget()) ) {
-                    logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
+                logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
 
-                    filename = this.getFileName(resource.getPath());
+                filename = this.getFileName(resource.getPath());
 
-                    var messageObj = {
-                        "location" : {
-                            "filename": filename,
-                        },
-                        "source": {
-                            "$t": resource.getSource()
-                        }
-                    };
-
-                    if (resource.getSource() !== resource.getKey()) {
-                        messageObj["comment"] = {
-                            "$t": resource.getKey()
-                        }
+                var messageObj = {
+                    "location" : {
+                        "filename": filename,
+                    },
+                    "source": {
+                        "$t": resource.getSource()
                     }
-                    messageObj["translation"] = {
-                        "$t": resource.getTarget()
+                };
+
+                if (resource.getKey() && resource.getSource() !== resource.getKey()) {
+                    messageObj["comment"] = {
+                        "$t": resource.getKey()
                     }
+                }
+                messageObj["translation"] = {
+                    "$t": resource.getTarget()
+                }
 
-                    if (typeof (resource.getComment()) !== "undefined") {
-                        messageObj["extracomment"] = {
-                            "$t": resource.getComment()
-                        }
+                if (typeof (resource.getComment()) !== "undefined") {
+                    messageObj["extracomment"] = {
+                        "$t": resource.getComment()
                     }
+                }
 
-                    if (fileList.indexOf(filename) !== -1) {
-                        for (var i=0; i< content["context"].length; i++) {
-                            if (content["context"][i]["name"]["$t"] === filename.replace(".qml", "")) {
-                                content["context"][i]["message"].push(messageObj);
-                                break;
-                            }
+                if (fileList.indexOf(filename) !== -1) {
+                    for (var i=0; i< content["context"].length; i++) {
+                        if (content["context"][i]["name"]["$t"] === filename.replace(".qml", "")) {
+                            content["context"][i]["message"].push(messageObj);
+                            break;
                         }
-
-                    } else {
-                        fileList.push(filename);
-                        var contextObj = {
-                            "name" :{
-                                "$t": filename.replace(".qml", "")
-                            },
-                            "message": []
-                        }
-                        contextObj["message"].push(messageObj);
-                        contextList.push(contextObj);
-                        content["context"] = contextList;
                     }
                 } else {
-                    logger.trace("skipping translation with no change");
+                    fileList.push(filename);
+                    var contextObj = {
+                        "name" :{
+                            "$t": filename.replace(".qml", "")
+                        },
+                        "message": []
+                    }
+                    contextObj["message"].push(messageObj);
+                    contextList.push(contextObj);
+                    content["context"] = contextList;
                 }
             } else {
                 logger.warn("String resource " + resource.getKey() + " has no source text. Skipping...");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -543,6 +543,63 @@ module.exports.tsresourcefile = {
 
         test.done()
     },
+    testTSResourceFileRightContentsSourceTargetSame2: function(test) {
+        test.expect(2);
+
+        var tsrf = new TSResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        test.ok(tsrf);
+        [
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                key: "source text key",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "source text"
+            },
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                sourceLocale: "en-US",
+                source: "source text ",
+                target: "source text "
+            }
+        ].forEach(function(res) {
+            var resource = new SourceContextResourceString(res);
+            tsrf.addResource(resource);
+        });
+
+        test.equal(tsrf.getContent(),
+         '<?xml version="1.0" encoding="utf-8"?>\n' +
+         '<!DOCTYPE TS>\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
+         '  <context>\n' +
+         '    <name>Test</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <comment>source text key</comment>\n' +
+         '      <translation>source text</translation>\n' +
+         '    </message>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>source text </source>\n' +
+         '      <translation>source text </translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '</TS>'
+        );
+
+        test.done()
+    },
     testTSResourceFileRightContentsKeyTargetSame: function(test) {
         test.expect(2);
 
@@ -615,7 +672,92 @@ module.exports.tsresourcefile = {
          '<?xml version="1.0" encoding="utf-8"?>\n' +
          '<!DOCTYPE TS>\n' +
          '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
-         '  <context></context>\n' +
+         '  <context>\n' +
+         '    <name>Test</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <translation>source text</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '</TS>'
+        );
+
+        test.done()
+    },
+    testTSResourceFileRightContentsSourceKeyTargetSame2: function(test) {
+        test.expect(2);
+
+        var tsrf = new TSResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        test.ok(tsrf);
+        [
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                key: "source text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "source text"
+            },
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test.qml",
+                targetLocale: "de-DE",
+                key: "more source text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "more source text",
+                context: "Test"
+            },
+            {
+                type: "string",
+                project: "inputcommon",
+                pathName: "./Test2.qml",
+                targetLocale: "de-DE",
+                key: "more source text",
+                sourceLocale: "en-US",
+                source: "source text2",
+                target: "source text2",
+                context: "Test"
+            },
+        ].forEach(function(res) {
+            var resource = new SourceContextResourceString(res);
+            tsrf.addResource(resource);
+        });
+
+        test.equal(tsrf.getContent(),
+         '<?xml version="1.0" encoding="utf-8"?>\n' +
+         '<!DOCTYPE TS>\n' +
+         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
+         '  <context>\n' +
+         '    <name>Test</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>more source text</source>\n' +
+         '      <translation>more source text</translation>\n' +
+         '    </message>\n' +
+         '    <message>\n' +
+         '      <location filename="Test.qml"></location>\n' +
+         '      <source>source text</source>\n' +
+         '      <translation>source text</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '  <context>\n' +
+         '    <name>Test2</name>\n' +
+         '    <message>\n' +
+         '      <location filename="Test2.qml"></location>\n' +
+         '      <source>source text2</source>\n' +
+         '      <comment>more source text</comment>\n' +
+         '      <translation>source text2</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
          '</TS>'
         );
 


### PR DESCRIPTION
* Updated code to generate resource even though source and target are the same and add related test cases.

Currently, we don't generate resources when the source and target are the same.  but It causes an issue. When we change the locale from Korean to English, QML tries to load `em.qm` file. but there isn't. so It just remains Korean even though the setting is English.  I expected to show the source string in that case, but it didn't.  so I updated the code to generate resources all the time no matter what the source and target are the same. (Java loctool does the same thing)
