### PR TITLE
Added ability to override language default locale.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.0
+* Added ability to override language default locale.
+
 v1.2.10
 * Updated dependencies. (loctool: 2.17.0)
 

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -20,9 +20,9 @@
 var fs = require("fs");
 var path = require("path");
 var Locale = require("ilib/lib/Locale.js");
-var LocaleMatcher = require("ilib/lib/LocaleMatcher.js");
 var xml2json = require("xml2json");
 var PrettyData = require("pretty-data").pd;
+var Utils = require("loctool/lib/utils.js");
 
 /**
  * @class Represents an ts resource file.
@@ -37,16 +37,14 @@ var PrettyData = require("pretty-data").pd;
  * @param {Object} props properties that control the construction of this file.
  */
 var TSResourceFile = function(props) {
-    var lanDefaultLocale;
-
     this.project = props.project;
     this.locale = new Locale(props.locale);
     this.API = props.project.getAPI();
     this.logger = this.API.getLogger("loctool.plugin.webOSTSResourceFile");
-    this.minimalLocale = new LocaleMatcher({locale: props.locale}).getLikelyLocaleMinimal().getSpec();
-    lanDefaultLocale = new LocaleMatcher({locale: this.locale.language}).getLikelyLocaleMinimal().getSpec();
-    this.baseLocale = lanDefaultLocale === this.minimalLocale;
-
+    if (this.project.localeMap){
+        Utils.setBaseLocale(props.project.localeMap);
+    }
+    this.baseLocale = Utils.isBaseLocale(this.locale.getSpec());
     this.set = this.API.newTranslationSet(this.project && this.project.sourceLocale || "en-US");
 };
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.17.0",
+        "loctool": "2.18.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.2.10",
+    "version": "1.3.0",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",
@@ -48,7 +48,7 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.15.0",
+        "ilib": "^14.15.1",
         "pretty-data": "^0.40.0",
         "xml2json": "^0.12.0"
     },

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * testTSResourceFile.js - test the ts file handler object.
  *
- * Copyright (c) 2020-2021, JEDLSoft
+ * Copyright (c) 2020-2022, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,21 @@ var p2 = new CustomProject({
     identify: true
 });
 
+var p3 = new CustomProject({
+    id: "quicksettings",
+    projectType: "webos-qml",
+    sourceLocale: "en-KR",
+    resourceDirs: {
+        "ts": "locales"
+        }
+    }, "./testfiles", {
+    locales:["es-CO", "es-ES", "fr-CA","fr-FR"],
+    localeMap: {
+        "es-CO":"es",
+        "fr-CA":"fr"
+    }
+});
+
 module.exports.tsresourcefile = {
     testTSResourceFileConstructor: function(test) {
         test.expect(1);
@@ -91,7 +106,6 @@ module.exports.tsresourcefile = {
 
         test.ok(tsrf);
         test.ok(!tsrf.isDirty());
-
 
         [
             {
@@ -1156,6 +1170,26 @@ module.exports.tsresourcefile = {
         for (var i=0; i<locales.length;i++) {
             tsrf = new TSResourceFile({
                 project: p2,
+                locale: locales[i]
+            });
+            test.equal(tsrf.getResourceFilePath(), expected[i]);
+        }
+        test.done();
+    },
+    teasTSResourceFileGetResourceFilePathsCustom: function(test) {
+        test.expect(4);
+        var tsrf;
+        var locales = ["es-CO", "es-ES", "fr-CA","fr-FR"];
+
+        var expected = [
+            "testfiles/locales/quicksettings_es.ts",
+            "testfiles/locales/quicksettings_es_ES.ts",
+            "testfiles/locales/quicksettings_fr.ts",
+            "testfiles/locales/quicksettings_fr_FR.ts"
+        ];
+        for (var i=0; i<locales.length;i++) {
+            tsrf = new TSResourceFile({
+                project: p3,
                 locale: locales[i]
             });
             test.equal(tsrf.getResourceFilePath(), expected[i]);


### PR DESCRIPTION
Added ability to override language default locale and test case.
dependent loctool version should be `2.18.0` at least which hasn't published yet.
sample app: https://github.com/iLib-js/ilib-loctool-samples/pull/27