### PR TITLE
Replace xml2json  package to xml-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ v1.0.0
 
 ## License
 
-Copyright (c) 2020-2022, JEDLSoft
+Copyright (c) 2020-2023, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.4.0
+* Replaced dependent `xml2json` package to `xml-js`
+
 v1.3.1
 * Updated dependencies. (loctool: 2.20.0)
 

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -182,7 +182,7 @@ TSResourceFile.prototype.getContent = function() {
                         "_text": resource.getSource()
                     },
                     "translation":{
-                        "_text": resource.getSource()
+                        "_text": resource.getTarget()
                     }
                 }
 
@@ -190,9 +190,6 @@ TSResourceFile.prototype.getContent = function() {
                     messageObj.comment = {
                         "_text": resource.getKey()
                     }
-                }
-                messageObj.translation = {
-                    "_text": resource.getTarget()
                 }
 
                 if (typeof (resource.getComment()) !== "undefined") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",
@@ -50,7 +50,7 @@
     "dependencies": {
         "ilib": "^14.15.1",
         "pretty-data": "^0.40.0",
-        "xml2json": "^0.12.0"
+        "xml-js": "^1.6.11"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * testTSResourceFile.js - test the ts file handler object.
  *
- * Copyright (c) 2020-2022, JEDLSoft
+ * Copyright (c) 2020-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Hello</name>\n' +
          '    <message>\n' +
-         '      <location filename="Hello.qml"></location>\n' +
+         '      <location filename="Hello.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellentext</translation>\n' +
          '      <extracomment>i18n comments</extracomment>\n' +
@@ -216,7 +216,7 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Hello</name>\n' +
          '    <message>\n' +
-         '      <location filename="Hello.qml"></location>\n' +
+         '      <location filename="Hello.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellentext</translation>\n' +
          '    </message>\n' +
@@ -268,12 +268,12 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellen text</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellen text</translation>\n' +
          '    </message>\n' +
@@ -335,12 +335,12 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellen text</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellen text</translation>\n' +
          '    </message>\n' +
@@ -348,7 +348,7 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Translation</name>\n' +
          '    <message>\n' +
-         '      <location filename="Translation.qml"></location>\n' +
+         '      <location filename="Translation.qml"/>\n' +
          '      <source>yet more source text</source>\n' +
          '      <translation>noch mehr Quellen text</translation>\n' +
          '    </message>\n' +
@@ -413,12 +413,12 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellen text</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellen text</translation>\n' +
          '    </message>\n' +
@@ -426,7 +426,7 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test2</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellen text</translation>\n' +
          '    </message>\n' +
@@ -490,24 +490,24 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellen text</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
-         '      <comment>source text key1</comment>\n' +
          '      <translation>Quellen text</translation>\n' +
+         '      <comment>source text key1</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '  <context>\n' +
          '    <name>Test2</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>source text</source>\n' +
-         '      <comment>source text key3</comment>\n' +
          '      <translation>Quellen text</translation>\n' +
+         '      <comment>source text key3</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'
@@ -546,10 +546,10 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
-         '      <comment>source text key</comment>\n' +
          '      <translation>source text</translation>\n' +
+         '      <comment>source text key</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'
@@ -598,13 +598,13 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
-         '      <comment>source text key</comment>\n' +
          '      <translation>source text</translation>\n' +
+         '      <comment>source text key</comment>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text </source>\n' +
          '      <translation>source text </translation>\n' +
          '    </message>\n' +
@@ -646,10 +646,10 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text one</source>\n' +
-         '      <comment>more source text</comment>\n' +
          '      <translation>more source text</translation>\n' +
+         '      <comment>more source text</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'
@@ -689,7 +689,7 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>source text</translation>\n' +
          '    </message>\n' +
@@ -753,12 +753,12 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>more source text</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>source text</translation>\n' +
          '    </message>\n' +
@@ -766,10 +766,10 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test2</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>source text2</source>\n' +
-         '      <comment>more source text</comment>\n' +
          '      <translation>source text2</translation>\n' +
+         '      <comment>more source text</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'
@@ -819,16 +819,16 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
-         '      <comment>duplicated keys</comment>\n' +
          '      <translation>Quellen text</translation>\n' +
+         '      <comment>duplicated keys</comment>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
-         '      <comment>duplicated keys</comment>\n' +
          '      <translation>mehr Quellen text</translation>\n' +
+         '      <comment>duplicated keys</comment>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'
@@ -1059,17 +1059,17 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellentext</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellentext</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test.qml"></location>\n' +
+         '      <location filename="Test.qml"/>\n' +
          '      <source>yet more source text</source>\n' +
          '      <translation>noch mehr Quellentext</translation>\n' +
          '    </message>\n' +
@@ -1131,17 +1131,17 @@ module.exports.tsresourcefile = {
          '  <context>\n' +
          '    <name>Test2</name>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>more source text</source>\n' +
          '      <translation>mehr Quellentext</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>source text</source>\n' +
          '      <translation>Quellentext</translation>\n' +
          '    </message>\n' +
          '    <message>\n' +
-         '      <location filename="Test2.qml"></location>\n' +
+         '      <location filename="Test2.qml"/>\n' +
          '      <source>yet more source text</source>\n' +
          '      <translation>noch mehr Quellentext</translation>\n' +
          '    </message>\n' +


### PR DESCRIPTION
In order to generate xml type of output, plugin use `xml2json` package which has a `node-expat` dependency
Having a dependency on `node-expat` is not good in higher versions of node. (there was an issue during webOS build as well)
Also, xml2json repository has been archived by the  owner.
so I I've decided to adopt different one `xml-js` which is also used loctool.