### PR TITLE
Update to set context name value propely which is not always a file name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-ts-resource is a plugin for the loctool that
 allows it to read and localize ts resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.5.0
+* 
+
 v1.4.2
 * Updated dependencies. (loctool: 2.21.0)
 * Fixed not to have file extension in name element with js file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ allows it to read and localize ts resource files. This plugins is optimized for 
 
 ## Release Notes
 v1.5.0
-* 
+* Update to set context name value propely which is not always a file name.
 
 v1.4.2
 * Updated dependencies. (loctool: 2.21.0)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ allows it to read and localize ts resource files. This plugins is optimized for 
 
 ## Release Notes
 v1.5.0
-* Update to set context name value propely which is not always a file name.
+* Update to set context name value properly which is not always a file name.
 
 v1.4.2
 * Updated dependencies. (loctool: 2.21.0)

--- a/TSResourceFile.js
+++ b/TSResourceFile.js
@@ -149,7 +149,7 @@ function clean(str) {
  */
 TSResourceFile.prototype.getContent = function() {
     var content = {}, json = {};
-    var fileList = [], contextList = [];
+    var contextNameList = [], contextList = [];
 
     if (this.set.isDirty()) {
         var resources = this.set.getAll();
@@ -162,6 +162,7 @@ TSResourceFile.prototype.getContent = function() {
         for (var j = 0; j < resources.length; j++) {
             var resource = resources[j];
             var filename = this.getFileName(resource.getPath());
+            var resContext = resource.getContext() || filename.replace(/\.qml|\.js/, "");
 
             if (content["context"] === undefined) {
                 content["context"] = {};
@@ -169,8 +170,6 @@ TSResourceFile.prototype.getContent = function() {
 
             if (resource.getSource() && resource.getTarget()) {
                 this.logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
-
-                filename = this.getFileName(resource.getPath());
 
                 var messageObj = {
                     "location": {
@@ -198,18 +197,18 @@ TSResourceFile.prototype.getContent = function() {
                     }
                 }
 
-                if (fileList.indexOf(filename) !== -1) {
+                if (contextNameList.indexOf(resContext) !== -1) {
                     for (var i=0; i< content["context"].length; i++) {
-                        if (content["context"][i]["name"]["_text"] === filename.replace(/\.qml|\.js/, "")) {
+                        if (content["context"][i]["name"]["_text"] === resContext) {
                             content["context"][i]["message"].push(messageObj);
                             break;
                         }
                     }
                 } else {
-                    fileList.push(filename);
+                    contextNameList.push(resContext);
                     var contextObj = {
                         "name" :{
-                            "_text": filename.replace(/\.qml|\.js/, "")
+                            "_text": resContext
                         },
                         "message": []
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-ts-resource",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "main": "./TSResourceFileType.js",
     "description": "A loctool plugin that knows how to process ts resource files",
     "license": "Apache-2.0",
@@ -48,13 +48,13 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.17.0",
+        "ilib": "^14.18.0",
         "pretty-data": "^0.40.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.21.0",
+        "loctool": "2.22.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -1291,6 +1291,61 @@ module.exports.tsresourcefile = {
 
         test.done();
     },
+    testTSResourceFileGetContentwithContext: function(test) {
+        test.expect(2);
+
+        var tsrf = new TSResourceFile({
+            project: p2,
+            locale: "ko-KR"
+        });
+
+        test.ok(tsrf);
+
+        [
+            {
+                type: "string",
+                project: "quicksettings",
+                targetLocale: "ko-KR",
+                pathName: "./System.js",
+                key: "This function is not supported.",
+                sourceLocale: "en-KR",
+                source: "This function is not supported.",
+                target: "이 기능은 지원하지 않습니다.",
+                context: "appLaunch"
+            },
+            {
+                type: "string",
+                project: "quicksettings",
+                targetLocale: "ko-KR",
+                pathName: "./appLaunch.js",
+                key: "This function is not supported.",
+                sourceLocale: "en-KR",
+                source: "This function is not supported.",
+                target: "이 기능은 지원하지 않습니다.",
+                context: "appLaunch"
+            },
+        ].forEach(function(res) {
+            var resource = new SourceContextResourceString(res);
+            tsrf.addResource(resource);
+        });
+
+        test.equal(tsrf.getContent(),
+         '<?xml version="1.0" encoding="utf-8"?>\n' +
+         '<!DOCTYPE TS>\n' +
+         '<TS version="2.1" language="ko-KR" sourcelanguage="en-KR">\n' +
+         '  <context>\n' +
+         '    <name>appLaunch</name>\n' +
+         '    <message>\n' +
+         '      <location filename="System.js"/>\n' +
+         '      <source>This function is not supported.</source>\n' +
+         '      <translation>이 기능은 지원하지 않습니다.</translation>\n' +
+         '    </message>\n' +
+         '  </context>\n' +
+         '</TS>'
+        );
+
+        test.done();
+    },
     teasTSResourceFileGetResourceFilePaths: function(test) {
         test.expect(13);
         var tsrf;

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -538,7 +538,7 @@ module.exports.tsresourcefile = {
          '<!DOCTYPE TS>\n' +
          '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
          '  <context>\n' +
-         '    <name>JString</name>\n' +
+         '    <name>Hello</name>\n' +
          '    <message>\n' +
          '      <location filename="JString.js"/>\n' +
          '      <source>source text</source>\n' +
@@ -868,8 +868,8 @@ module.exports.tsresourcefile = {
                 targetLocale: "de-DE",
                 key: "source text",
                 sourceLocale: "en-US",
-                source: "source text",
-                target: "source text"
+                source: "1.source text",
+                target: "1.source text"
             },
             {
                 type: "string",
@@ -878,20 +878,20 @@ module.exports.tsresourcefile = {
                 targetLocale: "de-DE",
                 key: "more source text",
                 sourceLocale: "en-US",
-                source: "more source text",
-                target: "more source text",
-                context: "Test"
+                source: "2.more source text",
+                target: "2.more source text",
+                context: "contextTest"
             },
             {
                 type: "string",
                 project: "inputcommon",
                 pathName: "./Test2.qml",
                 targetLocale: "de-DE",
-                key: "more source text",
+                key: "source text2",
                 sourceLocale: "en-US",
-                source: "source text2",
-                target: "source text2",
-                context: "Test"
+                source: "3.source text2",
+                target: "3.source text2",
+                context: "contextTest"
             },
         ].forEach(function(res) {
             var resource = new SourceContextResourceString(res);
@@ -899,32 +899,34 @@ module.exports.tsresourcefile = {
         });
 
         test.equal(tsrf.getContent(),
-         '<?xml version="1.0" encoding="utf-8"?>\n' +
-         '<!DOCTYPE TS>\n' +
-         '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
-         '  <context>\n' +
-         '    <name>Test</name>\n' +
-         '    <message>\n' +
-         '      <location filename="Test.qml"/>\n' +
-         '      <source>more source text</source>\n' +
-         '      <translation>more source text</translation>\n' +
-         '    </message>\n' +
-         '    <message>\n' +
-         '      <location filename="Test.qml"/>\n' +
-         '      <source>source text</source>\n' +
-         '      <translation>source text</translation>\n' +
-         '    </message>\n' +
-         '  </context>\n' +
-         '  <context>\n' +
-         '    <name>Test2</name>\n' +
-         '    <message>\n' +
-         '      <location filename="Test2.qml"/>\n' +
-         '      <source>source text2</source>\n' +
-         '      <translation>source text2</translation>\n' +
-         '      <comment>more source text</comment>\n' +
-         '    </message>\n' +
-         '  </context>\n' +
-         '</TS>'
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<!DOCTYPE TS>\n' +
+        '<TS version="2.1" language="de-DE" sourcelanguage="en-KR">\n' +
+        '  <context>\n' +
+        '    <name>contextTest</name>\n' +
+        '    <message>\n' +
+        '      <location filename="Test.qml"/>\n' +
+        '      <source>2.more source text</source>\n' +
+        '      <translation>2.more source text</translation>\n' +
+        '      <comment>more source text</comment>\n' +
+        '    </message>\n' +
+        '    <message>\n' +
+        '      <location filename="Test2.qml"/>\n' +
+        '      <source>3.source text2</source>\n' +
+        '      <translation>3.source text2</translation>\n' +
+        '      <comment>source text2</comment>\n' +
+        '    </message>\n' +
+        '  </context>\n' +
+        '  <context>\n' +
+        '    <name>Test</name>\n' +
+        '    <message>\n' +
+        '      <location filename="Test.qml"/>\n' +
+        '      <source>1.source text</source>\n' +
+        '      <translation>1.source text</translation>\n' +
+        '      <comment>source text</comment>\n' +
+        '    </message>\n' +
+        '  </context>\n' +
+        '</TS>'
         );
 
         test.done()

--- a/test/testTSResourceFile.js
+++ b/test/testTSResourceFile.js
@@ -1310,7 +1310,7 @@ module.exports.tsresourcefile = {
                 key: "This function is not supported.",
                 sourceLocale: "en-KR",
                 source: "This function is not supported.",
-                target: "이 기능은 지원하지 않습니다.",
+                target: "사용할 수 없는 기능입니다.",
                 context: "appLaunch"
             },
             {
@@ -1321,7 +1321,7 @@ module.exports.tsresourcefile = {
                 key: "This function is not supported.",
                 sourceLocale: "en-KR",
                 source: "This function is not supported.",
-                target: "이 기능은 지원하지 않습니다.",
+                target: "사용할 수 없는 기능입니다.",
                 context: "appLaunch"
             },
         ].forEach(function(res) {
@@ -1338,7 +1338,7 @@ module.exports.tsresourcefile = {
          '    <message>\n' +
          '      <location filename="System.js"/>\n' +
          '      <source>This function is not supported.</source>\n' +
-         '      <translation>이 기능은 지원하지 않습니다.</translation>\n' +
+         '      <translation>사용할 수 없는 기능입니다.</translation>\n' +
          '    </message>\n' +
          '  </context>\n' +
          '</TS>'


### PR DESCRIPTION
* Update to set context name value properly which is not always a file name.
  * related change: https://github.com/iLib-js/ilib-loctool-webos-qml/pull/39  